### PR TITLE
Changing how directories is managed

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -74,6 +74,12 @@ class composer (
   }
 
   $composer_full_path = "${composer_target_dir}/${composer_command_name}"
+
+  file { "${composer_target_dir}":
+    ensure  => directory,
+    owner   => $composer_user,
+  }
+
   exec { 'composer-install':
     command => "/usr/bin/wget --no-check-certificate -O ${composer_full_path} ${target}",
     user    => $composer_user,
@@ -88,6 +94,12 @@ class composer (
     mode    => '0755',
     group   => $group,
     require => Exec['composer-install'],
+  }
+
+  file { "/usr/local/bin/composer":
+    ensure  => link,
+    force   => true,
+    target  => "${composer_target_dir}/${composer_command_name}"
   }
 
   if $auto_update {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -14,7 +14,7 @@
 #
 class composer::params {
   $phar_location = 'https://getcomposer.org/composer.phar'
-  $target_dir    = '/usr/local/bin'
+  $target_dir    = '/opt/composer'
   $command_name  = 'composer'
   $user          = 'root'
   $version       = undef


### PR DESCRIPTION
Changing default directory from /usr/local/bin to /opt/composer
Also create directory before install composer and force link creation from /opt/composer/composer to /usr/local/bin/composer

### Overview

Describe here what your PR is actually doing including information like whether you've observed possible BC breaks.

### Related issues

If your PR solves issues, they should be referenced here.
